### PR TITLE
Delete course key fix

### DIFF
--- a/Organizely/src/app/classes-page/classes-page.component.html
+++ b/Organizely/src/app/classes-page/classes-page.component.html
@@ -39,6 +39,7 @@
         <tr>
           <th scope="col">Class Time</th>
           <th scope="col">Class Name</th>
+          <th scope="col">Teacher</th>
           <th scope="col">Edit</th>
           <th scope="col">Delete</th>
         </tr>
@@ -53,6 +54,7 @@
             </span>
           </td>
           <td>{{ course.courseName }}</td>
+          <td>{{ course.teacherName }}</td>
           <td>
             <button
               class="btn btn-dark"
@@ -118,6 +120,7 @@
             <tr>
               <th scope="col">Class Time</th>
               <th scope="col">Class Name</th>
+              <th scope="col">Teacher</th>
               <th scope="col">Edit</th>
               <th scope="col">Delete</th>
             </tr>
@@ -133,6 +136,7 @@
                 </span>
               </td>
               <td>{{ course.value["courseName"] }}</td>
+              <td>{{ course.value["teacherName"] }}</td>
               <td>
                 <button
                   class="btn btn-dark"

--- a/Organizely/src/app/classes-page/classes-page.component.ts
+++ b/Organizely/src/app/classes-page/classes-page.component.ts
@@ -79,7 +79,7 @@ export class ClassesPageComponent implements OnInit {
           ) {
             delete this.semestersBySchoolYear[
               this.currentSemester['semesterYear']
-            ];
+            ][this.currentSemester['semesterSeason']];
           }
         },
         (error: any) => {


### PR DESCRIPTION
I fixed a bug that was occurring on the `classes-page` component. Lines 80-82 initially deleted the key that represented a year (ex. 2021) instead of a season (ex. Spring). 

```ts
delete this.semestersBySchoolYear[
              this.currentSemester['semesterYear']];
```

I ensured that it deletes the key representing the season with the following code:

```ts
delete this.semestersBySchoolYear[
              this.currentSemester['semesterYear']
            ][this.currentSemester['semesterSeason']];
```