### PR TITLE
Fix current date bug on upcoming-list component

### DIFF
--- a/Organizely/src/app/calendar-page/calendar-page.component.ts
+++ b/Organizely/src/app/calendar-page/calendar-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import {
   CalendarOptions,
@@ -22,7 +22,7 @@ import createCalendarEvents from '../shared/utils/createCalendarEvents';
   templateUrl: './calendar-page.component.html',
   styleUrls: ['./calendar-page.component.css'],
 })
-export class CalendarPageComponent implements OnInit, OnDestroy {
+export class CalendarPageComponent implements OnInit {
   selectedDate: Date;
   calendarVisible: boolean = true;
   calendarOptions: CalendarOptions = {
@@ -40,8 +40,8 @@ export class CalendarPageComponent implements OnInit, OnDestroy {
   assignments: Assignment[];
   courses: Course[];
   studentTasks: StudentTask[];
-  calendarSub: Subscription;
   calendarModal;
+
   constructor(
     private router: Router,
     private coursesService: CoursesService,
@@ -49,6 +49,7 @@ export class CalendarPageComponent implements OnInit, OnDestroy {
     private assignmentsService: AssignmentsService,
     private calendarService: CalendarService
   ) {}
+
   ngOnInit(): void {
     this.coursesService.getCourses().subscribe((data: Course[]) => {
       this.courses = data;
@@ -74,9 +75,6 @@ export class CalendarPageComponent implements OnInit, OnDestroy {
           );
         });
     });
-    this.calendarSub = this.calendarService.currentDate.subscribe(
-      (date) => (this.selectedDate = date)
-    );
   }
   addEvent(selectInfo: DateSelectArg) {
     this.calendarService.changeDate(selectInfo['date']);
@@ -121,11 +119,6 @@ export class CalendarPageComponent implements OnInit, OnDestroy {
           clickInfo.event.id,
         ]);
       }
-    }
-  }
-  ngOnDestroy() {
-    if (this.calendarSub !== undefined) {
-      this.calendarSub.unsubscribe();
     }
   }
 }

--- a/Organizely/src/app/shared/calendar.service.ts
+++ b/Organizely/src/app/shared/calendar.service.ts
@@ -5,17 +5,11 @@ import { BehaviorSubject, Subject } from 'rxjs';
   providedIn: 'root',
 })
 export class CalendarService {
-  // private date = new Subject<Date>();
-  // public date$ = this.date.asObservable();
-
   private dateSource = new BehaviorSubject<Date>(new Date());
   currentDate = this.dateSource.asObservable();
 
   constructor() {}
 
-  // emitDate(x: any) {
-  //   this.date.next(x);
-  // }
   changeDate(date: Date) {
     this.dateSource.next(date);
   }

--- a/Organizely/src/app/upcoming-list/upcoming-list.component.ts
+++ b/Organizely/src/app/upcoming-list/upcoming-list.component.ts
@@ -41,10 +41,12 @@ export class UpcomingListComponent implements OnInit, OnDestroy {
           .subscribe((studentTasks: StudentTask[]) => {
             this.studentTasks = studentTasks;
 
+            this.currentDate = new Date();
+
+            this.calendarService.changeDate(this.currentDate);
+
             this.upcomingListSub = this.calendarService.currentDate.subscribe(
               (date) => {
-                this.currentDate = new Date(date);
-
                 let newDate = new Date(this.currentDate);
 
                 let dateOneCalculation = newDate.setDate(newDate.getDate() + 7);


### PR DESCRIPTION
I fixed the bug that occurred on the `upcoming-list` component. It resets the current date back to the correct date after a user navigates back to it after switching the current date from the `calendar-view` component. It's ready to be reviewed and merged to the `main` branch.